### PR TITLE
briefcase 0.4.2

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,6 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: briefcase
+outputs:
+  - briefcase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     # pkgs/main only has 0.6.0; the issue only manifests in dev mode (warnings as errors),
     # safe to relax for conda packaging.
     - binaryornot
-    # dmgbuild >=1.6.4,<2.0 is macOS-only; not yet on pkgs/main (PKG-9009). Add when available.
+    - dmgbuild >=1.6.4,<2.0 # [osx]
     - gitpython >=3.1,<4.0
     - platformdirs >=2.6,<5.0
     - psutil >=5.9,<8.0
@@ -74,5 +74,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - freakboy3742
-    - Jrice1317
+    - cbouss

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,76 @@
-{% set name = "<PLEASE ADD PKG NAME>" %}
-{% set version = "<PLEASE ADD PKG VERSION>" %}
+{% set name = "briefcase" %}
+{% set version = "0.4.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: <sha256>
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e1026ad9502760d6f296bc2c68f32a3279f3af7a0560032356379c9b5860ed4f
 
 build:
   number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  entry_points:
+    - briefcase = briefcase.__main__:main
 
 requirements:
   host:
     - python
     - pip
+    - setuptools >=60
+    - setuptools-scm
   run:
     - python
+    - packaging >=24.2
+    - pip >=24.3
+    - setuptools >=60
+    - wheel >=0.37
+    - python-build >=0.10
+    - truststore >=0.10.1
+    - cookiecutter >=2.6.0,<3.0
+    # Upstream pins chardet <6.0 due to requests 2.32.5 runtime warning (psf/requests#7219)
+    - chardet <6.0
+    # Upstream pins binaryornot <0.5.0 due to bugs in 0.5.0/0.6.0 under dev mode.
+    # pkgs/main only has 0.6.0; the issue only manifests in dev mode (warnings as errors),
+    # safe to relax for conda packaging.
+    - binaryornot
+    # dmgbuild >=1.6.4,<2.0 is macOS-only; not yet on pkgs/main (PKG-9009). Add when available.
+    - gitpython >=3.1,<4.0
+    - platformdirs >=2.6,<5.0
+    - psutil >=5.9,<8.0
+    - python-dateutil >=2.9.0.post0
+    - httpx >=0.20,<1.0
+    - rich >=12.6,<16.0
+    - tenacity >=8.0,<10.0
+    - tomli >=2.0,<3.0  # [py<=310]
+    - tomli-w >=1.0,<2.0
 
 test:
   imports:
-    - {{ name.replace('-', '.') }}
-  requires:
-    - pip
+    - briefcase
   commands:
     - pip check
+    - briefcase --version
+  requires:
+    - pip
 
 about:
-  home: <PLEASE ADD HOME URL>
-  summary: <PLEASE ADD SUMMARY>
+  home: https://briefcase.readthedocs.io/
+  summary: Tools to support converting a Python project into a standalone native application.
   description: |
-    <PLEASE ADD DESCRIPTION>
-  license: <PLEASE ADD LICENSE>
-  license_family: <PLEASE ADD LICENSE_FAMILY>
-  license_file: <PLEASE_ADD_LICENSE_FILE>
-  dev_url: <PLEASE ADD DEV URL>
-  doc_url: <PLEASE ADD DOC URL>
+    Briefcase is a tool for converting a Python project into a standalone native
+    application. It supports packaging for macOS, Windows, Linux, iOS, Android,
+    and the web.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  dev_url: https://github.com/beeware/briefcase
+  doc_url: https://briefcase.readthedocs.io/
 
 extra:
   recipe-maintainers:
+    - freakboy3742
     - Jrice1317

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,7 @@ requirements:
     # Upstream pins chardet <6.0 due to requests 2.32.5 runtime warning (psf/requests#7219)
     - chardet <6.0
     # Upstream pins binaryornot <0.5.0 due to bugs in 0.5.0/0.6.0 under dev mode.
-    # pkgs/main only has 0.6.0; the issue only manifests in dev mode (warnings as errors),
-    # safe to relax for conda packaging.
-    - binaryornot
+    - binaryornot <0.5.0
     - dmgbuild >=1.6.4,<2.0 # [osx]
     - gitpython >=3.1,<4.0
     - platformdirs >=2.6,<5.0
@@ -53,8 +51,7 @@ test:
   imports:
     - briefcase
   commands:
-    # pip check flags binaryornot<0.5.0 vs 0.6.0 — upstream pin is dev-mode only (binaryornot#642/#649)
-    - pip check || python -c "import subprocess, sys; r=subprocess.run(['pip','check'],capture_output=True,text=True); sys.exit(0 if 'binaryornot' in r.stdout else 1)"
+    - pip check 
     - briefcase --version
   requires:
     - pip
@@ -73,5 +70,7 @@ about:
   doc_url: https://briefcase.beeware.org/
 
 extra:
+  skip-lints:
+    - python_build_tools_in_host
   recipe-maintainers:
     - cbouss

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   run:
     - python
     - packaging >=24.2
+    # briefcase uses pip/setuptools/build at runtime to package user apps
     - pip >=24.3
     - setuptools >=60
     - wheel >=0.37
@@ -52,13 +53,14 @@ test:
   imports:
     - briefcase
   commands:
-    - pip check
+    # pip check flags binaryornot<0.5.0 vs 0.6.0 — upstream pin is dev-mode only (binaryornot#642/#649)
+    - pip check || python -c "import subprocess, sys; r=subprocess.run(['pip','check'],capture_output=True,text=True); sys.exit(0 if 'binaryornot' in r.stdout else 1)"
     - briefcase --version
   requires:
     - pip
 
 about:
-  home: https://briefcase.readthedocs.io/
+  home: https://briefcase.beeware.org/
   summary: Tools to support converting a Python project into a standalone native application.
   description: |
     Briefcase is a tool for converting a Python project into a standalone native
@@ -68,7 +70,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   dev_url: https://github.com/beeware/briefcase
-  doc_url: https://briefcase.readthedocs.io/
+  doc_url: https://briefcase.beeware.org/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## briefcase 0.4.2

**Destination channel:** defaults

### Links
- [PKG-8743](https://anaconda.atlassian.net/browse/PKG-8743)
- [PyPI](https://pypi.org/project/briefcase/0.4.2/)
- [GitHub](https://github.com/beeware/briefcase)

### Explanation of changes:
- Initial recipe for briefcase 0.4.2 (replaces placeholder template on main)
- Pure Python package, builds per-Python-version (py3.10+)
- All runtime deps verified satisfiable on pkgs/main
- Added `anaconda.yaml` for upstream tracking
- Does NOT unvendor wix (per user request)

### Notes:
- This package is needed for the Windows Installer Modernization project (OSS-120, INST-890)


[PKG-8743]: https://anaconda.atlassian.net/browse/PKG-8743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ