### PR TITLE
briefcase 0.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "briefcase" %}
-{% set version = "0.4.2" %}
+{% set version = "0.4.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e1026ad9502760d6f296bc2c68f32a3279f3af7a0560032356379c9b5860ed4f
+  sha256: 9814899daab8c5f1faeb96896986986948668d6effc32fe25ed850e2cc81b29d
 
 build:
   number: 0
@@ -38,7 +38,7 @@ requirements:
     # pkgs/main only has 0.6.0; the issue only manifests in dev mode (warnings as errors),
     # safe to relax for conda packaging.
     - binaryornot
-    # dmgbuild >=1.6.4,<2.0 is macOS-only; not yet on pkgs/main (PKG-9009). Add when available.
+    - dmgbuild >=1.6.4,<2.0  # [osx]
     - gitpython >=3.1,<4.0
     - platformdirs >=2.6,<5.0
     - psutil >=5.9,<8.0


### PR DESCRIPTION
## briefcase 0.4.3

**Destination channel:** defaults

### Links
- [PKG-16154](https://anaconda.atlassian.net/browse/PKG-16154)
- [PyPI](https://pypi.org/project/briefcase/0.4.3/)
- [GitHub](https://github.com/beeware/briefcase)

### Explanation of changes:
- Updated briefcase from 0.4.2 to 0.4.3
- Added `dmgbuild >=1.6.4,<2.0  # [osx]` — now available on pkgs/main (1.6.7, shipped via PKG-9009)
- Kept relaxed `binaryornot` (no upper bound) — pkgs/main only has 0.6.0; upstream's `<0.5.0` pin is for dev-mode warnings only (binaryornot#642/#649)
- No other dependency changes upstream between 0.4.2 and 0.4.3

### Notes:
- Supersedes PR #4 (from upstream maintainer) which reintroduced solver-breaking pins (`binaryornot <0.5.0`, `dmgbuild` without pkgs/main availability check from before PKG-9009 shipped)
- This package is needed for the Windows Installer Modernization project (OSS-120, INST-890)
- Urgency: 🔴 Urgent — Miniconda installers work depends on this version

[PKG-16154]: https://anaconda.atlassian.net/browse/PKG-16154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ