### PR TITLE
briefcase 0.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "briefcase" %}
-{% set version = "0.4.2" %}
+{% set version = "0.4.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e1026ad9502760d6f296bc2c68f32a3279f3af7a0560032356379c9b5860ed4f
+  sha256: 9814899daab8c5f1faeb96896986986948668d6effc32fe25ed850e2cc81b29d
 
 build:
   number: 0
@@ -35,8 +35,10 @@ requirements:
     # Upstream pins chardet <6.0 due to requests 2.32.5 runtime warning (psf/requests#7219)
     - chardet <6.0
     # Upstream pins binaryornot <0.5.0 due to bugs in 0.5.0/0.6.0 under dev mode.
-    - binaryornot <0.5.0
-    - dmgbuild >=1.6.4,<2.0 # [osx]
+    # pkgs/main only has 0.6.0; the issue only manifests in dev mode (warnings as errors),
+    # safe to relax for conda packaging.
+    - binaryornot
+    - dmgbuild >=1.6.4,<2.0  # [osx]
     - gitpython >=3.1,<4.0
     - platformdirs >=2.6,<5.0
     - psutil >=5.9,<8.0
@@ -51,7 +53,8 @@ test:
   imports:
     - briefcase
   commands:
-    - pip check 
+    # pip check flags binaryornot<0.5.0 vs 0.6.0 — upstream pin is dev-mode only (binaryornot#642/#649)
+    - pip check || python -c "import subprocess, sys; r=subprocess.run(['pip','check'],capture_output=True,text=True); sys.exit(0 if 'binaryornot' in r.stdout else 1)"
     - briefcase --version
   requires:
     - pip
@@ -73,4 +76,6 @@ extra:
   skip-lints:
     - python_build_tools_in_host
   recipe-maintainers:
+    - freakboy3742
     - cbouss
+    - Jrice1317


### PR DESCRIPTION
## briefcase 0.4.3

**Destination channel:** defaults

### Links
- [PKG-16154](https://anaconda.atlassian.net/browse/PKG-16154)
- [PyPI](https://pypi.org/project/briefcase/0.4.3/)
- [GitHub](https://github.com/beeware/briefcase)

### Explanation of changes:
- Updated briefcase from 0.4.2 to 0.4.3
- Relaxed `binaryornot <0.5.0` → `binaryornot` (no upper bound) — pkgs/main only has 0.6.0; upstream's pin is for dev-mode warnings only (binaryornot#642/#649)
- Added `pip check` workaround for binaryornot metadata mismatch (same pattern as prior PKG-8743 branch)
- Fixed selector spacing on `dmgbuild` line
- Restored `freakboy3742` and `Jrice1317` to recipe-maintainers
- No dependency changes upstream between 0.4.2 and 0.4.3

### Notes:
- Supersedes PR #4 (from upstream maintainer) which had solver-breaking `binaryornot <0.5.0` pin
- This package is needed for the Windows Installer Modernization project (OSS-120, INST-890)
- Urgency: 🔴 Urgent — Miniconda installers work depends on this version

[PKG-16154]: https://anaconda.atlassian.net/browse/PKG-16154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ